### PR TITLE
Quell uninitialised-value warnings on empty string

### DIFF
--- a/lib/String/CamelSnakeKebab.pm
+++ b/lib/String/CamelSnakeKebab.pm
@@ -38,6 +38,8 @@ our $WORD_SEPARATOR_PATTERN = qr/
 sub convert_case {
     my ($first_coderef, $rest_coderef, $separator, $string) = @_;
 
+    return '' if $string eq '';
+
     my ($first, @rest) = split $WORD_SEPARATOR_PATTERN, $string;
 
     my @words = $first_coderef->($first);

--- a/t/convert_case.t
+++ b/t/convert_case.t
@@ -22,4 +22,11 @@ while ( my ($expected_answer, $test_this) = each %tests ) {
 
 }
 
+{
+    my $warnings = 0;
+    local $SIG{__WARN__} = sub { $warnings++ };
+    is( lower_snake_case(''), '', 'empty string unchanged' );
+    is( $warnings, 0, 'empty string causes no warnings' );
+}
+
 done_testing;


### PR DESCRIPTION
Previously, passing an empty string to any of the case-conversion functions produced an uninitialised-value warning. This change fixes that.

Thanks!
