### PR TITLE
Export a word_split() function for custom processing of identifiers

### DIFF
--- a/lib/String/CamelSnakeKebab.pm
+++ b/lib/String/CamelSnakeKebab.pm
@@ -10,6 +10,7 @@ use Sub::Exporter -setup => { exports => [qw/
     constant_case
     kebab_case
     http_header_case
+    word_split
 /]};
 
 our $VERSION = "0.05";
@@ -35,12 +36,16 @@ our $WORD_SEPARATOR_PATTERN = qr/
     )
 /x;
 
+sub word_split {
+    split $WORD_SEPARATOR_PATTERN, $_[0];
+}
+
 sub convert_case {
     my ($first_coderef, $rest_coderef, $separator, $string) = @_;
 
     return '' if $string eq '';
 
-    my ($first, @rest) = split $WORD_SEPARATOR_PATTERN, $string;
+    my ($first, @rest) = word_split($string);
 
     $first = '' unless $first;
 
@@ -104,6 +109,12 @@ String::CamelSnakeKebab - word case conversion
     http_header_case "x-ssl-cipher"
     # => "X-SSL-Cipher"
 
+    word_split 'ASnakeSlithersSlyly'
+    # => ["A", "Snake", "Slithers", "Slyly"]
+
+    word_split 'flux-capacitor'
+    # => ["flux", "capacitor"]
+
 
 =head1 DESCRIPTION
 
@@ -125,6 +136,8 @@ is ported from the original Clojure.
 =head2 kebab_case()
 
 =head2 http_header_case()
+
+=head2 word_split()
 
 =head1 ERROR HANDLING
 

--- a/t/word_split.t
+++ b/t/word_split.t
@@ -1,7 +1,5 @@
 use Test::Most;
-use String::CamelSnakeKebab;
-
-my $separator = $String::CamelSnakeKebab::WORD_SEPARATOR_PATTERN;
+use String::CamelSnakeKebab qw< word_split >;
 
 my %tests = (
     "foo bar"    => [qw/foo bar/],
@@ -17,7 +15,7 @@ my %tests = (
     "foo1Bar"    => [qw/foo1 Bar/],
 );
 
-cmp_deeply [ split $separator, $_ ] => $tests{$_}, 
+cmp_deeply [ word_split($_) ] => $tests{$_},
     sprintf "%8s -> %s", $_, join " ", @{ $tests{$_} }
         for sort keys %tests;
 


### PR DESCRIPTION
Alternatively the package could document `$WORD_SEPARATOR_PATTERN`, but exporting a function seems cleaner.